### PR TITLE
Adds support for reading brightness on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,22 +7,5 @@ if (process.platform === 'darwin') {
 } else if (process.platform === 'linux') {
 	module.exports = require('xdg-brightness');
 } else {
-	module.exports.set = function (val, cb) {
-		if (typeof val !== 'number' || val < 0 || val > 1) {
-			throw new Error('Expected a number between 0 and 1');
-		}
-
-		nircmd(['setbrightness', toPercent(val)], function (err) {
-			if (err) {
-				cb(err);
-				return;
-			}
-
-			cb();
-		});
-	};
-
-	module.exports.get = function () {
-		throw new Error('Getting brightness is only supported on OS X and Linux systems');
-	};
+	module.exports = require('win-brightness');
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   ],
   "dependencies": {
     "nircmd": "^1.1.1",
+    "win-brightness": "^1.0.0",
     "osx-brightness": "^3.0.1",
     "to-percent": "^1.0.2",
     "xdg-brightness": "^2.0.1"

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ brightness.set(0.8, function (err) {
 
 ### .get(callback)
 
-Get brightness level. *Doesn't work on Windows systems.*
+Get brightness level.
 
 #### callback(err, level)
 

--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ if (!process.env.CI) {
 
 			brightness.get(function (err, brightness) {
 				t.assert(!err, err);
-				t.assert(parseInt(brightness) === 0.5);
+				t.assert(brightness === 0.5);
 			});
 		});
 	});


### PR DESCRIPTION
Adds dependency on win-brightness.
Removes parseInt from unit test, fails on win-brightness. Needs verification on OS X/Linux.