### PR TITLE
Add support for xbacklight on Linux

### DIFF
--- a/lib/linux-xbacklight.js
+++ b/lib/linux-xbacklight.js
@@ -1,0 +1,24 @@
+var xbacklight = require('xbacklight');
+var Promise = require('pinkie-promise');
+
+function get() {
+	return new Promise(function (resolve, reject) {
+		xbacklight.get()
+		.then(function (val) {
+			resolve(val / 100);
+		})
+		.catch(function (err) {
+			reject(err);
+		});
+	});
+}
+
+function set(val) {
+	return xbacklight.set(val * 100);
+}
+
+module.exports = {
+	isInstalledSync: xbacklight.isInstalledSync,
+	get: get,
+	set: set
+};

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -3,6 +3,13 @@ var fs = require('fs');
 var path = require('path');
 var pify = require('pify');
 var Promise = require('pinkie-promise');
+var linuxXbacklight = require('./linux-xbacklight');
+
+if (linuxXbacklight.isInstalledSync()) {
+	module.exports = linuxXbacklight;
+	return;
+}
+
 var fsP = pify(fs, Promise);
 
 module.exports.get = function () {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "osx-brightness": "^4.0.0",
     "pify": "^2.3.0",
     "pinkie-promise": "^2.0.0",
-    "wmi-client": "^0.2.0"
+    "wmi-client": "^0.2.0",
+    "xbacklight": "^1.0.1"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
Allows for changing the brightness without sudoing

Debian/Ubuntu users can install using `apt-get install xbacklight`
